### PR TITLE
Remove dependabot reviewers

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,5 +6,3 @@ updates:
     interval: monthly
     time: "05:30"
     timezone: Europe/London
-  reviewers:
-    - "martincostello"


### PR DESCRIPTION
Remove dependabot reviewers as the option is deprecated.